### PR TITLE
docs: ADD issue template, ADD PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: aceforeverd
+---
+
+**Bug Description**
+
+
+
+**Expected Behavior**
+
+
+
+**Steps to Reproduce**
+
+1. 
+2. 
+3. 
+4. 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the feature you'd like**
+
+A clear and concise description of what you want to happen.
+
+
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+* **What is the current behavior?** (You can also link to an open issue here)
+
+
+
+* **What is the new behavior (if this is a feature change)?**
+


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update


* **What is the current behavior?** (You can also link to an open issue here)
there are no templates when raising ISSUE and PR


* **What is the new behavior (if this is a feature change)?**
default templates are added for ISSUE and PR 
