### PR TITLE
doc/fix: update contributing doc link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Here is the general contribution workflow:
 - Fork the PMedis repository into your personal space
 - Create a branch from where you want to base your code (usually it is the main branch)
 - Make commits of your code and test cases, make sure:
-  - your coding style follows our [code convention](https://github.com/memark-io/pmedis/doc/style-guide/code-convention.md)
-  - the commit messages follow our [commit convention](https://github.com/memark-io/pmedis/doc/style-guide/commit-convention.md)
+  - your coding style follows our [code convention](https://github.com/memark-io/pmedis/blob/main/doc/style-guide/code-convention.md)
+  - the commit messages follow our [commit convention](https://github.com/memark-io/pmedis/blob/main/doc/style-guide/commit-convention.md)
 
 - Push your commits to your forked repository
 - Submit a pull request to merge from your branch to the PMedis's main branch
@@ -36,7 +36,7 @@ You may find us from the following channels for any help about contribution
 
 ## Contribution Opportunities
 
-If you just would like to begin your journey to contribute to PMedis community, the issues with the label of `good first issue` is certainly a good start for you. [Please visit here for this issue list](https://github.com/4paradigm/OpenMLDB/issues).
+If you just would like to begin your journey to contribute to PMedis community, the issues with the label of `good first issue` is certainly a good start for you. [Please visit here for this issue list](https://github.com/memark-io/pmedis/issues).
 
 
 ## Contributors

--- a/doc/style-guide/code-convention.md
+++ b/doc/style-guide/code-convention.md
@@ -2,7 +2,7 @@
 
 [summary]: summary
 
-4Paradigm's coding convention apply to C/CPP, Java, Scala, Python, Yaml, Json, Shell Script.
+Coding convention apply to C/CPP, Java, Scala, Python, Yaml, Json, Shell Script.
 
 # Motivation
 

--- a/doc/style-guide/commit-convention.md
+++ b/doc/style-guide/commit-convention.md
@@ -32,7 +32,7 @@ rule 1 and 2 is enforced.
 
 Follow the issue template defined in each project, which should at least have
 
-- bug report tempate: e.g [bug report](https://github.com/4paradigm/fedb/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
+- bug report tempate: e.g [bug report](https://github.com/memark-io/pmedis/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
 - feature request template
 
 ## Pull Request
@@ -43,7 +43,7 @@ Follow the issue template defined in each project, which should at least have
    - `merge`, `squash merge` and `rebase merge` are all allowed.
    - maintainer should decide the right action, not mess up the commit tree.
 2. PR Template
-   - A Pull Request Template like [PR template](https://github.com/4paradigm/fedb/blob/main/.github/pull_request_template.md) should provided.
+   - A Pull Request Template like [PR template](https://github.com/memark-io/pmedis/blob/main/.github/pull_request_template.md) should provided.
 3. Conditions to suffice before merge
    - reach pre-defined approval number
    - CI all pass


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
update links for [code convention] and [commit convention]
update links such as issues, pr template and point them to pmedis repo

* **What is the current behavior?** (You can also link to an open issue here)
[code convention] and [commit convention] that listed on CONTRIBUTING.md can not access.


* **What is the new behavior (if this is a feature change)?**
[code convention] and [commit convention] can be accessed
