### PR TITLE
fix: pm.setrange and pm.ltrim command

### DIFF
--- a/src/t_plist.c
+++ b/src/t_plist.c
@@ -420,6 +420,8 @@ int pmLtrimCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (start < 0) start = 0;
   }
   if (end < 0) end = list_sz + end;
+  if (end >= (long long)list_sz) end = list_sz - 1;
+  // avoid end > list_sz because kvdk api(05f720b) has problem for now
   if ((start >= list_sz) || (end < 0) || (start > end)) {
     // clear the whole list
     KVDKListIterator *iter =

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -738,6 +738,7 @@ int pmSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
                  size_t *new_val_len, void *args_pointer) {
   // assert(args_pointer);
+  *new_val = (char *)malloc(MAX_KVDK_STRING_SIZE);
   SetRangeArgs *args = (SetRangeArgs *)args_pointer;
   const char *val_str = args->val_str;
   size_t val_len = args->val_len;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix of pm.setrange and pm.ltrim


* **What is the current behavior?** (You can also link to an open issue here)
This PR is intended to solve issue #24 and #28 
Now PMedis performs the same behavior as original Redis

* **What is the new behavior (if this is a feature change)?**
None
