### PR TITLE
fix: setrange, ltrim and lset command

### DIFF
--- a/src/t_plist.c
+++ b/src/t_plist.c
@@ -338,11 +338,7 @@ int pmLsetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   size_t val_len;
   const char *val = RedisModule_StringPtrLen(argv[3], &val_len);
-  if (idx >= 0) {
-    KVDKListInsertAfter(engine, iter, val, val_len);
-  } else {
-    KVDKListInsertBefore(engine, iter, val, val_len);
-  }
+  s = KVDKListReplace(engine, iter, val, val_len);
 
   if (s == Ok) {
     RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -420,6 +416,9 @@ int pmLtrimCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (start < 0) start = 0;
   }
   if (end < 0) end = list_sz + end;
+  if (end >= (long long)list_sz) end = list_sz - 1;
+  /* avoid end > list_sz because kvdk SeekPos return NULL as both head
+  and tail node */
   if ((start >= list_sz) || (end < 0) || (start > end)) {
     // clear the whole list
     KVDKListIterator *iter =

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -738,6 +738,7 @@ int pmSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
                  size_t *new_val_len, void *args_pointer) {
   // assert(args_pointer);
+  *new_val = (char *)malloc(MAX_KVDK_STRING_SIZE);
   SetRangeArgs *args = (SetRangeArgs *)args_pointer;
   const char *val_str = args->val_str;
   size_t val_len = args->val_len;

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -738,7 +738,6 @@ int pmSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
                  size_t *new_val_len, void *args_pointer) {
   // assert(args_pointer);
-  *new_val = (char *)malloc(MAX_KVDK_STRING_SIZE);
   SetRangeArgs *args = (SetRangeArgs *)args_pointer;
   const char *val_str = args->val_str;
   size_t val_len = args->val_len;
@@ -747,6 +746,7 @@ int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
   /* Return existing string length when setting nothing */
   if (val_len == 0) {
     args->ll_strlen_after_result = old_val_len;
+    *new_val = NULL;  // Avoid crash
     args->err_no = RMW_SUCCESS;
     return KVDK_MODIFY_ABORT;
   }
@@ -756,6 +756,7 @@ int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
    * is 512 MB*/
   if (offset + val_len > MAX_KVDK_STRING_SIZE) {
     args->err_no = RMW_STRING_OVER_MAXSIZE;
+    *new_val = NULL;  // Avoid crash
     return KVDK_MODIFY_ABORT;
   }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
This PR is intended to solve issue #24, #28 and #29 
Now these three commands behaves the same as original Redis

* **What is the new behavior (if this is a feature change)?**
None
