### PR TITLE
Fix/string type issues

### DIFF
--- a/src/pmedis.c
+++ b/src/pmedis.c
@@ -56,20 +56,18 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
   //  return REDISMODULE_ERR;
   // String Commands
   RedisModule_Log(ctx, "notice", "dummy cmd created");
-  if (RedisModule_CreateCommand(ctx, "pm.del", pmDelCommand,
-                                "write deny-oom fast", 1, 1,
+  if (RedisModule_CreateCommand(ctx, "pm.del", pmDelCommand, "write", 1, -1,
                                 1) == REDISMODULE_ERR)
     return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "pm.exists", pmExistsCommand,
-                                "write deny-oom fast", 1, 1,
-                                1) == REDISMODULE_ERR)
+                                "readonly fast", 1, -1, 1) == REDISMODULE_ERR)
     return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "pm.ttl", pmTTLCommand,
-                                "write deny-oom fast", 1, 1,
+                                "readonly fast random", 1, 1,
                                 1) == REDISMODULE_ERR)
     return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "pm.pttl", pmPTTLCommand,
-                                "write deny-oom fast", 1, 1,
+                                "readonly fast random", 1, 1,
                                 1) == REDISMODULE_ERR)
     return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "pm.incr", pmIncrCommand,

--- a/src/pmedis.c
+++ b/src/pmedis.c
@@ -56,6 +56,22 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
   //  return REDISMODULE_ERR;
   // String Commands
   RedisModule_Log(ctx, "notice", "dummy cmd created");
+  if (RedisModule_CreateCommand(ctx, "pm.del", pmDelCommand,
+                                "write deny-oom fast", 1, 1,
+                                1) == REDISMODULE_ERR)
+    return REDISMODULE_ERR;
+  if (RedisModule_CreateCommand(ctx, "pm.exists", pmExistsCommand,
+                                "write deny-oom fast", 1, 1,
+                                1) == REDISMODULE_ERR)
+    return REDISMODULE_ERR;
+  if (RedisModule_CreateCommand(ctx, "pm.ttl", pmTTLCommand,
+                                "write deny-oom fast", 1, 1,
+                                1) == REDISMODULE_ERR)
+    return REDISMODULE_ERR;
+  if (RedisModule_CreateCommand(ctx, "pm.pttl", pmPTTLCommand,
+                                "write deny-oom fast", 1, 1,
+                                1) == REDISMODULE_ERR)
+    return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "pm.incr", pmIncrCommand,
                                 "write deny-oom fast", 1, 1,
                                 1) == REDISMODULE_ERR)

--- a/src/pmedis.h
+++ b/src/pmedis.h
@@ -95,6 +95,14 @@ extern int HelloKeys_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 extern int PmSleep_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
                                 int argc);
 // String commands
+extern int pmDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+                        int argc);
+extern int pmExistsCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+                           int argc);
+extern int pmTTLCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+                        int argc);
+extern int pmPTTLCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+                         int argc);
 extern int pmAppendCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
                            int argc);
 extern int pmIncrCommand(RedisModuleCtx *ctx, RedisModuleString **argv,

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -329,6 +329,10 @@ int pmAppendCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         safeStrcat(ori_val_str, ori_val_len, append_val_str, append_val_len);
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKPut(engine, key_str, key_len, target_str, target_len, write_option);
   free(ori_val_str);  // free memory allocated by KVDKGet
   RedisModule_Free(target_str);

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -126,12 +126,6 @@ int pmIncrCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Err WrongType");
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  // Every Operation with KVDKWriteOptions will erase previous TTL
-  // Because new WriteOption instance always have default value kPersistTTL
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -155,10 +149,6 @@ int pmDecrCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Err WrongType");
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -187,10 +177,6 @@ int pmIncrbyCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Err WrongType");
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -219,10 +205,6 @@ int pmDecrbyCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Err WrongType");
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -290,10 +272,6 @@ int pmIncrbyfloatCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     return RedisModule_ReplyWithError(ctx, "Err WrongType");
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, IncrbyFloatFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -329,10 +307,6 @@ int pmAppendCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         safeStrcat(ori_val_str, ori_val_len, append_val_str, append_val_len);
   }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKPut(engine, key_str, key_len, target_str, target_len, write_option);
   free(ori_val_str);  // free memory allocated by KVDKGet
   RedisModule_Free(target_str);
@@ -829,15 +803,7 @@ int pmSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
     KVDKWriteOptionsSetTTLTime(write_option, milliseconds);
   }
-  if (flags & OBJ_KEEPTTL) {
-    // KVDKPut will erase the previous TTL and persist a key by default
-    // set the expire time of previous key regardless of type
-    int64_t ttl_time;
-    s = KVDKGetTTL(engine, key_str, key_len, &ttl_time);
-    if (s == Ok && ttl_time != INT64_MAX) {
-      KVDKWriteOptionsSetTTLTime(write_option, ttl_time);
-    }
-  }
+  // todo: KEEPTTL option, wait for KVDK update
 
   if (flags & OBJ_SET_GET) {
     s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
@@ -952,10 +918,6 @@ int pmSetrangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   args.val_len = val_len;
   args.ll_offset = offset;
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  int64_t expire_time;
-  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
-  if (s == Ok && expire_time != INT64_MAX)
-    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
   s = KVDKModify(engine, key_str, key_len, setRangeFunc, &args, free,
                  write_option);
   KVDKDestroyWriteOptions(write_option);

--- a/src/t_pstring.c
+++ b/src/t_pstring.c
@@ -15,6 +15,63 @@
  */
 
 #include "pmedis.h"
+int pmDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  if (argc < 2) return RedisModule_WrongArity(ctx);
+  long long del_num = 0;
+  int j;
+  KVDKValueType type;
+  for (j = 1; j < argc; ++j) {
+    size_t key_len;
+    const char *key_str = RedisModule_StringPtrLen(argv[j], &key_len);
+    if (Ok == KVDKTypeOf(engine, key_str, key_len, &type)) {
+      DeleteKey(ctx, engine, key_str, key_len);
+      del_num++;
+    }
+  }
+  return RedisModule_ReplyWithLongLong(ctx, del_num);
+}
+
+int pmExistsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  if (argc < 2) return RedisModule_WrongArity(ctx);
+  long long exist_num = 0;
+  int j;
+  KVDKValueType type;
+  for (j = 1; j < argc; ++j) {
+    size_t key_len;
+    const char *key_str = RedisModule_StringPtrLen(argv[j], &key_len);
+    if (Ok == KVDKTypeOf(engine, key_str, key_len, &type)) exist_num++;
+  }
+  return RedisModule_ReplyWithLongLong(ctx, exist_num);
+}
+
+int pmTTLGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                        bool milli) {
+  if (argc != 2) return RedisModule_WrongArity(ctx);
+  size_t key_len;
+  const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
+  int64_t ttl_time;
+  KVDKStatus s = KVDKGetTTL(engine, key_str, key_len, &ttl_time);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
+  else if (s == NotFound)
+    return RedisModule_ReplyWithLongLong(ctx, -2);
+  else if (ttl_time == INT64_MAX)
+    return RedisModule_ReplyWithLongLong(ctx, -1);
+  else {
+    if (milli)
+      return RedisModule_ReplyWithLongLong(ctx, (long long)ttl_time);
+    else
+      return RedisModule_ReplyWithLongLong(ctx, (long long)(ttl_time / 1000));
+  }
+}
+
+int pmTTLCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return pmTTLGenericCommand(ctx, argv, argc, false);
+}
+
+int pmPTTLCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return pmTTLGenericCommand(ctx, argv, argc, true);
+}
 
 int IncrbyFunc(const char *old_val, size_t old_val_len, char **new_val,
                size_t *new_val_len, void *args_pointer) {
@@ -61,9 +118,22 @@ int pmIncrCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   IncNArgs args;
   args.ll_incr_by = 1;
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, KVDKStatusStrings[s]);
+  if (s == Ok && type != String) {
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
+  }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
-                            write_option);
+  // Every Operation with KVDKWriteOptions will erase previous TTL
+  // Because new WriteOption instance always have default value kPersistTTL
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
+                 write_option);
   KVDKDestroyWriteOptions(write_option);
 
   if (s != Ok)
@@ -77,9 +147,20 @@ int pmDecrCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   IncNArgs args;
   args.ll_incr_by = -1;
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, KVDKStatusStrings[s]);
+  if (s == Ok && type != String) {
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
+  }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
-                            write_option);
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
+                 write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok)
     return RMW_ErrMsgPrinter(ctx, args.err_no);
@@ -98,9 +179,20 @@ int pmIncrbyCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   IncNArgs args;
   args.ll_incr_by = incr;
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, KVDKStatusStrings[s]);
+  if (s == Ok && type != String) {
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
+  }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
-                            write_option);
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
+                 write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok)
     return RMW_ErrMsgPrinter(ctx, args.err_no);
@@ -119,9 +211,20 @@ int pmDecrbyCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   IncNArgs args;
   args.ll_incr_by = -decr;
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, KVDKStatusStrings[s]);
+  if (s == Ok && type != String) {
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
+  }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
-                            write_option);
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, IncrbyFunc, &args, free,
+                 write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok)
     return RMW_ErrMsgPrinter(ctx, args.err_no);
@@ -179,10 +282,20 @@ int pmIncrbyfloatCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   IncNArgs args;
   args.ld_incr_by = incr;
-
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok && s != NotFound)
+    return RedisModule_ReplyWithError(ctx, KVDKStatusStrings[s]);
+  if (s == Ok && type != String) {
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
+  }
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, IncrbyFloatFunc, &args,
-                            free, write_option);
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, IncrbyFloatFunc, &args, free,
+                 write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok)
     return RMW_ErrMsgPrinter(ctx, args.err_no);
@@ -203,18 +316,14 @@ int pmAppendCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   KVDKStatus s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
 
   if (s != Ok && s != NotFound) {
-    /* Something Err in KVDK */
+    /* Something Err in KVDK, This will include WrongType */
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
   } else if (s == NotFound) {
     /* Create the key */
     target_len = append_val_len;
     target_str = (char *)append_val_str;
   } else {
-    /* Key exists, check type */
-    // TODO: require KVDK support input key, output: key-type
-    // TODO: if(type != OBJ_STRING) return RedisModule_ReplyWithError(ctx,"ERR
-    // Wrong Type");
-    /* Append the value */
+    /* key exists, append the value */
     target_len = append_val_len + ori_val_len;
     target_str =
         safeStrcat(ori_val_str, ori_val_len, append_val_str, append_val_len);
@@ -243,10 +352,6 @@ int pmStrlenCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     /* Key not exist*/
     str_len = 0;
   } else {
-    /* Key exists, check type */
-    // TODO: require KVDK support input key, output: key-type
-    // TODO: if(type != OBJ_STRING) return RedisModule_ReplyWithError(ctx,"ERR
-    // Wrong Type");
     /* Append the value */
     str_len = val_len;
   }
@@ -268,7 +373,7 @@ int pmMsetGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     for (j = 1; j < argc; j += 2) {
       const char *key_str = RedisModule_StringPtrLen(argv[j], &key_len);
       s = KVDKGet(engine, key_str, key_len, &val_len, &val_str);
-      if (s == Ok) {
+      if (s == Ok || s == WrongType) {
         return RedisModule_ReplyWithLongLong(ctx, 0);
       }
     }
@@ -278,6 +383,16 @@ int pmMsetGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   for (j = 1; j < argc; j += 2) {
     const char *key_str = RedisModule_StringPtrLen(argv[j], &key_len);
     const char *val_str = RedisModule_StringPtrLen(argv[j + 1], &val_len);
+    // MSET never fail, it resets any key
+    if (!nx) {
+      KVDKValueType type;
+      s = KVDKTypeOf(engine, key_str, key_len, &type);
+      if (s == Ok && type != String) {
+        // We don't have to delete string first, slow performance
+        s = DeleteKey(ctx, engine, key_str, key_len);
+        if (s != Ok) return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
+      }
+    }
     KVDKWriteBatchStringPut(kvdk_wb, key_str, strlen(key_str), val_str,
                             strlen(val_str));
   }
@@ -307,9 +422,9 @@ int pmMgetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     const char *key_str = RedisModule_StringPtrLen(argv[i], &key_len);
     char *val_str;
     KVDKStatus s = KVDKGet(engine, key_str, key_len, &val_len, &val_str);
-    if (s != Ok && s != NotFound) {
+    if (s != Ok && s != NotFound && s != WrongType) {
       return RedisModule_ReplyWithError(ctx, "MGET KVDKGet Return Err");
-    } else if (s == NotFound) {
+    } else if (s == NotFound || s == WrongType) {
       RedisModule_ReplyWithNull(ctx);
     } else {
       RedisModule_ReplyWithStringBuffer(ctx, val_str, val_len);
@@ -463,7 +578,7 @@ int pmGetGenericCommand(RedisModuleCtx *ctx, const char *key_str,
   size_t val_len;
   char *val_str;
   *s = KVDKGet(engine, key_str, key_len, &val_len, &val_str);
-  if (*s != Ok && *s != NotFound) {
+  if (*s != Ok && *s != NotFound) {  // WrongType included
     return RedisModule_ReplyWithError(ctx, enum_to_str[*s]);
   } else if (NotFound == *s) {
     return RedisModule_ReplyWithNull(ctx);
@@ -493,7 +608,7 @@ int pmGetrangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithEmptyString(ctx);
   }
   KVDKStatus s = KVDKGet(engine, key_str, key_len, &val_len, &val_str);
-  if (s != Ok && s != NotFound) {
+  if (s != Ok && s != NotFound) {  // WrongType included
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
   } else if (NotFound == s) {
     return RedisModule_ReplyWithEmptyString(ctx);
@@ -520,7 +635,7 @@ int pmGetsetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   const char *val_str = RedisModule_StringPtrLen(argv[2], &val_len);
   KVDKStatus sGet, sSet;
-  pmGetGenericCommand(ctx, key_str, key_len, &sGet);
+  pmGetGenericCommand(ctx, key_str, key_len, &sGet);  // WrongType included
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
   sSet = KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
   KVDKDestroyWriteOptions(write_option);
@@ -537,9 +652,9 @@ int pmGetdelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   size_t key_len;
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   KVDKStatus sGet, sDel;
-  pmGetGenericCommand(ctx, key_str, key_len, &sGet);
+  pmGetGenericCommand(ctx, key_str, key_len, &sGet);  // WrongType included
   if (Ok == sGet) {
-    sDel = KVDKDelete(engine, key_str, key_len);
+    sDel = KVDKExpire(engine, key_str, key_len, 0);
     if (sDel != Ok) {
       return RedisModule_ReplyWithError(ctx, enum_to_str[sDel]);
     }
@@ -610,6 +725,7 @@ int pmGetexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
   }
   s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
+  // WrongType included
   if (s != Ok && s != NotFound) {
     free(ori_val_str);
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
@@ -624,7 +740,7 @@ int pmGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   size_t key_len;
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   KVDKStatus s;
-  return pmGetGenericCommand(ctx, key_str, key_len, &s);
+  return pmGetGenericCommand(ctx, key_str, key_len, &s);  // WrongType included
 }
 
 int pmSetexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -640,10 +756,13 @@ int pmSetexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "invalid expire time");
   }
   milliseconds *= 1000;
+  // SETEX never fail
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s == Ok && type != String) DeleteKey(ctx, engine, key_str, key_len);
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
   KVDKWriteOptionsSetTTLTime(write_option, milliseconds);
-  KVDKStatus s =
-      KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
+  s = KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok) {
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
@@ -661,10 +780,13 @@ int pmPsetexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (REDISMODULE_ERR == RedisModule_StringToLongLong(argv[2], &milliseconds)) {
     return RedisModule_ReplyWithError(ctx, "invalid expire time");
   }
+  // PSETEX never fail
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s == Ok && type != String) DeleteKey(ctx, engine, key_str, key_len);
   KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
   KVDKWriteOptionsSetTTLTime(write_option, milliseconds);
-  KVDKStatus s =
-      KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
+  s = KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
   KVDKDestroyWriteOptions(write_option);
   if (s != Ok) {
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
@@ -703,33 +825,55 @@ int pmSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
     KVDKWriteOptionsSetTTLTime(write_option, milliseconds);
   }
-
-  if ((flags & OBJ_SET_NX) || (flags & OBJ_SET_XX) || (flags & OBJ_SET_GET)) {
-    s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
-    // condition 1 NX set, but key exists --> then err
-    if (flags & OBJ_SET_NX && s == Ok) {
-      free(ori_val_str);
-      return RedisModule_ReplyWithNull(ctx);
-    }
-    // condition 2 XX set, but key not exists --> then err
-    if (flags & OBJ_SET_XX && s == NotFound) {
-      free(ori_val_str);
-      return RedisModule_ReplyWithNull(ctx);
+  if (flags & OBJ_KEEPTTL) {
+    // KVDKPut will erase the previous TTL and persist a key by default
+    // set the expire time of previous key regardless of type
+    int64_t ttl_time;
+    s = KVDKGetTTL(engine, key_str, key_len, &ttl_time);
+    if (s == Ok && ttl_time != INT64_MAX) {
+      KVDKWriteOptionsSetTTLTime(write_option, ttl_time);
     }
   }
 
+  if (flags & OBJ_SET_GET) {
+    s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
+    // WrongType included
+    if (s != Ok && s != NotFound) {
+      free(ori_val_str);
+      return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
+    }
+    // NotFound is allowed but we need to set first
+  }
+
+  KVDKValueType type;
+  s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if ((flags & OBJ_SET_NX) || (flags & OBJ_SET_XX)) {
+    // SET never fail regarding to types unless GET option
+    // condition 1 NX set, but key exists --> then (nil)
+    if (flags & OBJ_SET_NX && s == Ok) {
+      return RedisModule_ReplyWithNull(ctx);
+    }
+    // condition 2 XX set, but key not exists --> then (nil)
+    if (flags & OBJ_SET_XX && s == NotFound) {
+      return RedisModule_ReplyWithNull(ctx);
+    }
+  }
+  if (s == Ok && type != String) {
+    DeleteKey(ctx, engine, key_str, key_len);
+  }
   s = KVDKPut(engine, key_str, key_len, val_str, val_len, write_option);
   KVDKDestroyWriteOptions(write_option);
   if ((s == Ok) && (flags & OBJ_SET_GET)) {
-    RedisModule_ReplyWithStringBuffer(ctx, ori_val_str, ori_val_len);
-    free(ori_val_str);
-    return REDISMODULE_OK;
+    if (ori_val_str == NULL)
+      return RedisModule_ReplyWithNull(ctx);
+    else {
+      RedisModule_ReplyWithStringBuffer(ctx, ori_val_str, ori_val_len);
+      free(ori_val_str);
+      return REDISMODULE_OK;
+    }
   }
   if (s != Ok) {
     return RedisModule_ReplyWithError(ctx, enum_to_str[s]);
-  }
-  if ((flags & OBJ_SET_NX) || (flags & OBJ_SET_XX) || (flags & OBJ_SET_GET)) {
-    free(ori_val_str);
   }
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
@@ -782,14 +926,6 @@ int setRangeFunc(const char *old_val, size_t old_val_len, char **new_val,
   return KVDK_MODIFY_WRITE;
 }
 
-KVDKStatus setRange(const char *key_str, size_t key_len, SetRangeArgs *args) {
-  KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
-  KVDKStatus s = KVDKModify(engine, key_str, key_len, setRangeFunc, args, free,
-                            write_option);
-  KVDKDestroyWriteOptions(write_option);
-  return s;
-}
-
 int pmSetrangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc != 4) return RedisModule_WrongArity(ctx);
 
@@ -803,12 +939,23 @@ int pmSetrangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (offset < 0) {
     return RedisModule_ReplyWithError(ctx, "ERR offset is out of range");
   }
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s == Ok && type != String)
+    return RedisModule_ReplyWithError(ctx, "Err WrongType");
   const char *val_str = RedisModule_StringPtrLen(argv[3], &val_len);
   SetRangeArgs args;
   args.val_str = val_str;
   args.val_len = val_len;
   args.ll_offset = offset;
-  KVDKStatus s = setRange(key_str, key_len, &args);
+  KVDKWriteOptions *write_option = KVDKCreateWriteOptions();
+  int64_t expire_time;
+  s = KVDKGetTTL(engine, key_str, key_len, &expire_time);
+  if (s == Ok && expire_time != INT64_MAX)
+    KVDKWriteOptionsSetTTLTime(write_option, expire_time);
+  s = KVDKModify(engine, key_str, key_len, setRangeFunc, &args, free,
+                 write_option);
+  KVDKDestroyWriteOptions(write_option);
   if (s == Abort && args.err_no != RMW_SUCCESS) {
     return RMW_ErrMsgPrinter(ctx, args.err_no);
   } else {
@@ -822,7 +969,7 @@ int pmSetnxCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   const char *key_str = RedisModule_StringPtrLen(argv[1], &key_len);
   char *ori_val_str;
   KVDKStatus s = KVDKGet(engine, key_str, key_len, &ori_val_len, &ori_val_str);
-  if (s == Ok) {
+  if (s == Ok || s == WrongType) {
     return RedisModule_ReplyWithLongLong(ctx, 0);
   }
   const char *val_str = RedisModule_StringPtrLen(argv[2], &val_len);

--- a/src/util.c
+++ b/src/util.c
@@ -47,6 +47,26 @@ KVDKStatus RMW_ErrMsgPrinter(RedisModuleCtx* ctx, rmw_err_msg err_no) {
   }
 }
 
+KVDKStatus DeleteKey(RedisModuleCtx* ctx, KVDKEngine* engine,
+                     const char* key_str, size_t key_len) {
+  // key must exist
+  KVDKValueType type;
+  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
+  if (s != Ok) return s;
+  switch (type) {
+    case String:
+      return KVDKExpire(engine, key_str, key_len, 0);
+    case List:
+      return KVDKListDestroy(engine, key_str, key_len);
+    case HashSet:
+      return KVDKHashDestroy(engine, key_str, key_len);
+    case SortedSet:
+      return KVDKSortedDestroy(engine, key_str, key_len);
+    default:
+      return RedisModule_ReplyWithError(ctx, "Unknown Type");
+  }
+}
+
 char* safeStrcat(char* __restrict s1, size_t s1_size, const char* __restrict s2,
                  size_t s2_size) {
   size_t res_len = 1 + s1_size + s2_size;

--- a/src/util.c
+++ b/src/util.c
@@ -48,11 +48,8 @@ KVDKStatus RMW_ErrMsgPrinter(RedisModuleCtx* ctx, rmw_err_msg err_no) {
 }
 
 KVDKStatus DeleteKey(RedisModuleCtx* ctx, KVDKEngine* engine,
-                     const char* key_str, size_t key_len) {
-  // key must exist
-  KVDKValueType type;
-  KVDKStatus s = KVDKTypeOf(engine, key_str, key_len, &type);
-  if (s != Ok) return s;
+                     const char* key_str, size_t key_len, KVDKValueType type) {
+  // key must exist to avoid multiple calls of TypeOf()
   switch (type) {
     case String:
       return KVDKExpire(engine, key_str, key_len, 0);

--- a/src/util.h
+++ b/src/util.h
@@ -67,5 +67,5 @@ void DecodeScoreKey(char* score_key, size_t score_key_len, char** member,
                     size_t* member_len, int64_t* score);
 KVDKStatus RMW_ErrMsgPrinter(RedisModuleCtx* ctx, rmw_err_msg err_no);
 KVDKStatus DeleteKey(RedisModuleCtx* ctx, KVDKEngine* engine,
-                     const char* key_str, size_t key_len);
+                     const char* key_str, size_t key_len, KVDKValueType type);
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -66,4 +66,6 @@ void EncodeStringKey(const char* collection, size_t collection_len,
 void DecodeScoreKey(char* score_key, size_t score_key_len, char** member,
                     size_t* member_len, int64_t* score);
 KVDKStatus RMW_ErrMsgPrinter(RedisModuleCtx* ctx, rmw_err_msg err_no);
+KVDKStatus DeleteKey(RedisModuleCtx* ctx, KVDKEngine* engine,
+                     const char* key_str, size_t key_len);
 #endif


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix and new feature as well


* **What is the current behavior?** (You can also link to an open issue here)
This PR will fix all the issues that occur with String commands when you use non-string keys.  Before this PR, PMedis may return OK when encountering non-string keys or throw errors when it shouldn't with non-string keys.
And we have fixed some features that should be consistent with the original Redis including solving issue  #14. Specific behavior list is as follows:

- PM.GETDEL now can really delete the entry and the same key can be reused later with non-string types.
- PM.MGET can apply to any types, return (nil) when it's not string.
- PM.MSET never fails, it overwrites keys regardless of types.
- PM.SETEX never fails, it overwrites keys regardless of types.
- PM.PSETEX never fails, it overwrites keys regardless of types.
- PM.SET now overwrites keys regardless of types **unless GET option** still throws error with non-string key


* **What is the new behavior (if this is a feature change)?**
For the ease of testing, we add some new general commands with the identical function of original Redis. They are PM.DEL, PM.EXISTS, PM.TTL and PM.PTTL.
